### PR TITLE
Include stderr in error message

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,5 +1,17 @@
+import { shell } from "../lib/index"
+
 describe("shell()", () => {
-  it("example test", () => {
-    expect(true).toBe(true)
+  it("should not show stderr if not defined", () => {
+    expect(() => {
+      shell("boom")
+    }).toThrow("Command failed: boom")
+  })
+  it("should show stderr if defined", () => {
+    expect(() => {
+      shell("boom", { stdio: "pipe" })
+    }).toThrow("Command failed: boom")
+    expect(() => {
+      shell("boom", { stdio: "pipe" })
+    }).toThrow(/boom: not found/)
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,9 @@ function shellSync(
     }
     return null
   } catch (error) {
+    if (error.stderr !== null) {
+      error.message = `${error.message}\nSTDERR: ${error.stderr.toString()}`
+    }
     throw new ShellError(error.message)
   }
 }


### PR DESCRIPTION
Before this change, you could get a generic "command failed" when
`stdio: pipe` was set.

After this change, STDERR is included in the diagnostics, which can be
critical to finding out why a command failed.

Automated test for this turned out to be hard. I'm including a failing test. See the commit message about how it might be fixed. 